### PR TITLE
Prevent memory leak in capture thread

### DIFF
--- a/src/capturethread.cpp
+++ b/src/capturethread.cpp
@@ -93,8 +93,7 @@ void CaptureThread::run() {
                 outTransform.scale(1, -1);
             }
 
-            *qq = qq->transformed(outTransform);
-            emit renderedImage(*qq);
+            emit renderedImage(qq->transformed(outTransform));
         }
         free(asil);
         delete qq;


### PR DESCRIPTION
Don't lose reference to the original QImage object until destructor is called.
